### PR TITLE
refactor: move debug-level skip rule into Log entity

### DIFF
--- a/src/application/logUseCase.ts
+++ b/src/application/logUseCase.ts
@@ -31,7 +31,7 @@ export class LogUseCaseImpl implements LogUseCase {
       userId ? new LogUserId(userId) : null,
     );
 
-    if (log.level.value !== LogLevel.DEBUG) await this.logRepository.create(log);
+    if (log.shouldSave()) await this.logRepository.create(log);
 
     const output = {
       id: log.id.value,

--- a/src/domain/log/log.test.ts
+++ b/src/domain/log/log.test.ts
@@ -42,4 +42,26 @@ describe('Log', () => {
     expect(log.timestamp).toBe(timestamp);
     expect(log.userId).toBeNull();
   });
+
+  describe('shouldSave', () => {
+    const buildLog = (level: string) =>
+      new Log(
+        new Id(v4()),
+        new ServiceName('test-service'),
+        new Level(level),
+        new Message('Test log message'),
+        new Timestamp(new Date()),
+      );
+
+    it.each([Level.INFO, Level.WARN, Level.ERROR])(
+      'should return true when level is %s',
+      (level) => {
+        expect(buildLog(level).shouldSave()).toBe(true);
+      },
+    );
+
+    it('should return false when level is DEBUG', () => {
+      expect(buildLog(Level.DEBUG).shouldSave()).toBe(false);
+    });
+  });
 });

--- a/src/domain/log/log.test.ts
+++ b/src/domain/log/log.test.ts
@@ -53,15 +53,13 @@ describe('Log', () => {
         new Timestamp(new Date()),
       );
 
-    it.each([Level.INFO, Level.WARN, Level.ERROR])(
-      'should return true when level is %s',
-      (level) => {
-        expect(buildLog(level).shouldSave()).toBe(true);
-      },
-    );
-
-    it('should return false when level is DEBUG', () => {
-      expect(buildLog(Level.DEBUG).shouldSave()).toBe(false);
+    it.each(
+      Level.ALL.map((level) => ({
+        level,
+        expected: level !== Level.DEBUG,
+      })),
+    )('should return $expected when level is $level', ({ level, expected }) => {
+      expect(buildLog(level).shouldSave()).toBe(expected);
     });
   });
 });

--- a/src/domain/log/log.ts
+++ b/src/domain/log/log.ts
@@ -14,4 +14,8 @@ export class Log {
     readonly timestamp: Timestamp,
     readonly userId: UserId | null = null,
   ) {}
+
+  shouldSave(): boolean {
+    return this.level.value !== Level.DEBUG;
+  }
 }


### PR DESCRIPTION
## Summary
- Encapsulated the "skip persistence for DEBUG logs" rule inside the `Log` entity as `Log.shouldSave()`.
- Replaced the inline check `log.level.value !== LogLevel.DEBUG` in `LogUseCaseImpl.createLog` with `log.shouldSave()`.
- Added unit tests for `Log.shouldSave()` covering all log levels.

## Motivation
This rule is a domain invariant, not application orchestration. Moving it into the entity aligns with DDD / Clean Architecture by keeping domain logic out of the use-case layer and giving the entity a meaningful behavior beyond holding data.

## Test plan
- [x] `npx jest` (88/88 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)