### PR TITLE
refactor: focus use case on business logic

### DIFF
--- a/src/application/logUseCase.test.ts
+++ b/src/application/logUseCase.test.ts
@@ -1,4 +1,9 @@
+import { Level } from '../domain/log/level';
+import { Message } from '../domain/log/message';
 import { LogRepository } from '../domain/log/repository';
+import { ServiceName } from '../domain/log/serviceName';
+import { UserId } from '../domain/log/userId';
+import { Logger } from './logger';
 import { LogUseCaseImpl } from './logUseCase';
 
 describe('LogUseCase', () => {
@@ -8,52 +13,63 @@ describe('LogUseCase', () => {
       findAll: jest.fn(),
       findById: jest.fn(),
     };
-    const logUseCase = new LogUseCaseImpl(mockLogRepository);
-    return { mockLogRepository, logUseCase };
+    const mockLogger: jest.Mocked<Logger> = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    };
+    const logUseCase = new LogUseCaseImpl(mockLogRepository, mockLogger);
+    return { mockLogRepository, mockLogger, logUseCase };
   };
 
   describe('createLog', () => {
-    const levels = [
+    const cases = [
       { serviceName: 'test-service', level: 'ERROR', message: 'Test message', userId: 'user-id' },
       { serviceName: 'test-service', level: 'WARN', message: 'Test message', userId: undefined },
       { serviceName: 'test-service', level: 'INFO', message: 'Test message', userId: 'user-id' },
       { serviceName: 'test-service', level: 'DEBUG', message: 'Test message', userId: undefined },
     ];
-    it.each(levels)(
+    it.each(cases)(
       'should handle logging and persistence properly when level is %s and userId is %s',
       async ({ serviceName, level, message, userId }) => {
-        const { mockLogRepository, logUseCase } = setup();
+        const { mockLogRepository, mockLogger, logUseCase } = setup();
 
-        const spyConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
-        const spyConsoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
-        const spyConsoleLog = jest.spyOn(console, 'log').mockImplementation(() => {});
-
-        const log = await logUseCase.createLog(serviceName, level, message, userId);
+        const log = await logUseCase.createLog(
+          new ServiceName(serviceName),
+          new Level(level),
+          new Message(message),
+          userId ? new UserId(userId) : undefined,
+        );
 
         switch (level) {
           case 'ERROR':
             expect(mockLogRepository.create).toHaveBeenCalled();
-            expect(spyConsoleError).toHaveBeenCalled();
-            expect(spyConsoleWarn).not.toHaveBeenCalled();
-            expect(spyConsoleLog).not.toHaveBeenCalled();
+            expect(mockLogger.error).toHaveBeenCalled();
+            expect(mockLogger.warn).not.toHaveBeenCalled();
+            expect(mockLogger.info).not.toHaveBeenCalled();
+            expect(mockLogger.debug).not.toHaveBeenCalled();
             break;
           case 'WARN':
             expect(mockLogRepository.create).toHaveBeenCalled();
-            expect(spyConsoleWarn).toHaveBeenCalled();
-            expect(spyConsoleError).not.toHaveBeenCalled();
-            expect(spyConsoleLog).not.toHaveBeenCalled();
+            expect(mockLogger.warn).toHaveBeenCalled();
+            expect(mockLogger.error).not.toHaveBeenCalled();
+            expect(mockLogger.info).not.toHaveBeenCalled();
+            expect(mockLogger.debug).not.toHaveBeenCalled();
             break;
           case 'INFO':
             expect(mockLogRepository.create).toHaveBeenCalled();
-            expect(spyConsoleLog).toHaveBeenCalled();
-            expect(spyConsoleError).not.toHaveBeenCalled();
-            expect(spyConsoleWarn).not.toHaveBeenCalled();
+            expect(mockLogger.info).toHaveBeenCalled();
+            expect(mockLogger.error).not.toHaveBeenCalled();
+            expect(mockLogger.warn).not.toHaveBeenCalled();
+            expect(mockLogger.debug).not.toHaveBeenCalled();
             break;
           case 'DEBUG':
             expect(mockLogRepository.create).not.toHaveBeenCalled();
-            expect(spyConsoleLog).toHaveBeenCalled();
-            expect(spyConsoleError).not.toHaveBeenCalled();
-            expect(spyConsoleWarn).not.toHaveBeenCalled();
+            expect(mockLogger.debug).toHaveBeenCalled();
+            expect(mockLogger.error).not.toHaveBeenCalled();
+            expect(mockLogger.warn).not.toHaveBeenCalled();
+            expect(mockLogger.info).not.toHaveBeenCalled();
             break;
         }
 
@@ -61,10 +77,6 @@ describe('LogUseCase', () => {
         expect(log.level.value).toBe(level);
         expect(log.message.value).toBe(message);
         expect(log.userId?.value ?? null).toBe(userId ?? null);
-
-        spyConsoleError.mockRestore();
-        spyConsoleWarn.mockRestore();
-        spyConsoleLog.mockRestore();
       },
     );
   });

--- a/src/application/logUseCase.ts
+++ b/src/application/logUseCase.ts
@@ -1,34 +1,42 @@
-import { v4 } from 'uuid';
-import { ServiceName as LogServiceName } from '../domain/log';
 import { Id as LogId } from '../domain/log/id';
 import { Level as LogLevel } from '../domain/log/level';
 import { Log } from '../domain/log/log';
 import { Message as LogMessage } from '../domain/log/message';
 import { LogRepository } from '../domain/log/repository';
+import { ServiceName as LogServiceName } from '../domain/log/serviceName';
 import { Timestamp as LogTimestamp } from '../domain/log/timestamp';
 import { UserId as LogUserId } from '../domain/log/userId';
+import { Logger } from './logger';
 
 export interface LogUseCase {
-  createLog(serviceName: string, level: string, message: string, userId?: string): Promise<Log>;
+  createLog(
+    serviceName: LogServiceName,
+    level: LogLevel,
+    message: LogMessage,
+    userId?: LogUserId,
+  ): Promise<Log>;
   getAllLogs(): Promise<Log[]>;
 }
 
 export class LogUseCaseImpl implements LogUseCase {
-  constructor(private readonly logRepository: LogRepository) {}
+  constructor(
+    private readonly logRepository: LogRepository,
+    private readonly logger: Logger,
+  ) {}
 
   async createLog(
-    serviceName: string,
-    level: string,
-    message: string,
-    userId?: string,
+    serviceName: LogServiceName,
+    level: LogLevel,
+    message: LogMessage,
+    userId?: LogUserId,
   ): Promise<Log> {
     const log = new Log(
-      new LogId(v4()),
-      new LogServiceName(serviceName),
-      new LogLevel(level),
-      new LogMessage(message),
-      new LogTimestamp(new Date()),
-      userId ? new LogUserId(userId) : null,
+      LogId.generate(),
+      serviceName,
+      level,
+      message,
+      LogTimestamp.now(),
+      userId ?? null,
     );
 
     if (log.shouldSave()) await this.logRepository.create(log);
@@ -44,13 +52,16 @@ export class LogUseCaseImpl implements LogUseCase {
 
     switch (log.level.value) {
       case LogLevel.ERROR:
-        console.error(JSON.stringify(output));
+        this.logger.error(output);
         break;
       case LogLevel.WARN:
-        console.warn(JSON.stringify(output));
+        this.logger.warn(output);
+        break;
+      case LogLevel.DEBUG:
+        this.logger.debug(output);
         break;
       default:
-        console.log(JSON.stringify(output));
+        this.logger.info(output);
         break;
     }
 

--- a/src/application/logger.ts
+++ b/src/application/logger.ts
@@ -1,0 +1,6 @@
+export interface Logger {
+  info(payload: unknown): void;
+  warn(payload: unknown): void;
+  error(payload: unknown): void;
+  debug(payload: unknown): void;
+}

--- a/src/domain/log/id.test.ts
+++ b/src/domain/log/id.test.ts
@@ -1,4 +1,4 @@
-import { v4 } from 'uuid';
+import { v4, validate } from 'uuid';
 import { Id, InvalidIdError } from './id';
 
 describe('Id', () => {
@@ -11,5 +11,16 @@ describe('Id', () => {
   it('should throw an error for an invalid UUID', () => {
     const invalidUuid = 'not-a-uuid';
     expect(() => new Id(invalidUuid)).toThrow(InvalidIdError);
+  });
+
+  describe('generate', () => {
+    it('should produce an Id with a valid UUID', () => {
+      const id = Id.generate();
+      expect(validate(id.value)).toBe(true);
+    });
+
+    it('should produce a different Id on each call', () => {
+      expect(Id.generate().value).not.toBe(Id.generate().value);
+    });
   });
 });

--- a/src/domain/log/id.ts
+++ b/src/domain/log/id.ts
@@ -1,4 +1,4 @@
-import { validate } from 'uuid';
+import { v4, validate } from 'uuid';
 
 export class InvalidIdError extends Error {
   constructor(message: string) {
@@ -8,6 +8,10 @@ export class InvalidIdError extends Error {
 }
 
 export class Id {
+  static generate(): Id {
+    return new Id(v4());
+  }
+
   constructor(readonly value: string) {
     if (!validate(value)) {
       throw new InvalidIdError(`Invalid Id: ${value}`);

--- a/src/domain/log/timestamp.test.ts
+++ b/src/domain/log/timestamp.test.ts
@@ -6,4 +6,14 @@ describe('Timestamp', () => {
     const timestamp = new Timestamp(date);
     expect(timestamp.value).toBe(date);
   });
+
+  describe('now', () => {
+    it('should produce a Timestamp close to the current time', () => {
+      const before = Date.now();
+      const timestamp = Timestamp.now();
+      const after = Date.now();
+      expect(timestamp.value.getTime()).toBeGreaterThanOrEqual(before);
+      expect(timestamp.value.getTime()).toBeLessThanOrEqual(after);
+    });
+  });
 });

--- a/src/domain/log/timestamp.ts
+++ b/src/domain/log/timestamp.ts
@@ -1,3 +1,7 @@
 export class Timestamp {
+  static now(): Timestamp {
+    return new Timestamp(new Date());
+  }
+
   constructor(readonly value: Date) {}
 }

--- a/src/infrastructure/consoleLogger.test.ts
+++ b/src/infrastructure/consoleLogger.test.ts
@@ -1,0 +1,39 @@
+import { ConsoleLogger } from './consoleLogger';
+
+describe('ConsoleLogger', () => {
+  const setup = () => {
+    const logger = new ConsoleLogger();
+    const spyConsoleLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const spyConsoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const spyConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    return { logger, spyConsoleLog, spyConsoleWarn, spyConsoleError };
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should write info to console.log as JSON', () => {
+    const { logger, spyConsoleLog } = setup();
+    logger.info({ message: 'hello' });
+    expect(spyConsoleLog).toHaveBeenCalledWith(JSON.stringify({ message: 'hello' }));
+  });
+
+  it('should write warn to console.warn as JSON', () => {
+    const { logger, spyConsoleWarn } = setup();
+    logger.warn({ message: 'hello' });
+    expect(spyConsoleWarn).toHaveBeenCalledWith(JSON.stringify({ message: 'hello' }));
+  });
+
+  it('should write error to console.error as JSON', () => {
+    const { logger, spyConsoleError } = setup();
+    logger.error({ message: 'hello' });
+    expect(spyConsoleError).toHaveBeenCalledWith(JSON.stringify({ message: 'hello' }));
+  });
+
+  it('should write debug to console.log as JSON', () => {
+    const { logger, spyConsoleLog } = setup();
+    logger.debug({ message: 'hello' });
+    expect(spyConsoleLog).toHaveBeenCalledWith(JSON.stringify({ message: 'hello' }));
+  });
+});

--- a/src/infrastructure/consoleLogger.ts
+++ b/src/infrastructure/consoleLogger.ts
@@ -1,0 +1,19 @@
+import { Logger } from '../application/logger';
+
+export class ConsoleLogger implements Logger {
+  info(payload: unknown): void {
+    console.log(JSON.stringify(payload));
+  }
+
+  warn(payload: unknown): void {
+    console.warn(JSON.stringify(payload));
+  }
+
+  error(payload: unknown): void {
+    console.error(JSON.stringify(payload));
+  }
+
+  debug(payload: unknown): void {
+    console.log(JSON.stringify(payload));
+  }
+}

--- a/src/interface/logController.test.ts
+++ b/src/interface/logController.test.ts
@@ -53,10 +53,10 @@ describe('LogController', () => {
       await logController.createLog(req, res);
 
       expect(mockLogUseCase.createLog).toHaveBeenCalledWith(
-        'test-service',
-        'INFO',
-        'Test message',
-        'user-id',
+        new LogServiceName('test-service'),
+        new LogLevel('INFO'),
+        new LogMessage('Test message'),
+        new LogUserId('user-id'),
       );
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({
@@ -98,9 +98,9 @@ describe('LogController', () => {
       await logController.createLog(req, res);
 
       expect(mockLogUseCase.createLog).toHaveBeenCalledWith(
-        'test-service',
-        'INFO',
-        'Test message',
+        new LogServiceName('test-service'),
+        new LogLevel('INFO'),
+        new LogMessage('Test message'),
         undefined,
       );
       expect(res.status).toHaveBeenCalledWith(200);

--- a/src/interface/logController.ts
+++ b/src/interface/logController.ts
@@ -1,5 +1,9 @@
 import { Request, Response } from 'express';
 import { LogUseCase } from '../application/logUseCase';
+import { Level } from '../domain/log/level';
+import { Message } from '../domain/log/message';
+import { ServiceName } from '../domain/log/serviceName';
+import { UserId } from '../domain/log/userId';
 import { CreateLogRequest, CreateLogResponse, GetAllLogsResponse } from './logSchema';
 
 export class LogController {
@@ -7,9 +11,13 @@ export class LogController {
 
   createLog = async (req: Request, res: Response) => {
     const { serviceName, level, message } = req.body as CreateLogRequest;
-    const userId = req.userId;
 
-    const log = await this.logUseCase.createLog(serviceName, level, message, userId);
+    const log = await this.logUseCase.createLog(
+      new ServiceName(serviceName),
+      new Level(level),
+      new Message(message),
+      req.userId ? new UserId(req.userId) : undefined,
+    );
 
     const createLogResponse: CreateLogResponse = {
       id: log.id.value,

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import createClient from 'openapi-fetch';
 import { LogUseCaseImpl } from './application/logUseCase';
 import { AuthServiceImpl } from './infrastructure/api/auth/authService';
 import { paths as authPaths } from './infrastructure/api/auth/schema';
+import { ConsoleLogger } from './infrastructure/consoleLogger';
 import { LogRepositoryImpl } from './infrastructure/logRepository';
 import { LogController } from './interface/logController';
 import { createLogRoutes } from './interface/logRoutes';
@@ -21,7 +22,8 @@ const prisma = new PrismaClient();
 const logRepository = new LogRepositoryImpl(prisma);
 
 const authService = new AuthServiceImpl(authClient);
-const logUseCase = new LogUseCaseImpl(logRepository);
+const logger = new ConsoleLogger();
+const logUseCase = new LogUseCaseImpl(logRepository, logger);
 
 const authMiddleware = new AuthMiddleware(authService);
 const validateMiddleware = new ValidateMiddleware();


### PR DESCRIPTION
## Summary
- Build value objects in the controller and pass them into the use case, so the use case no longer performs input validation.
- Replace `new LogId(v4())` with `LogId.generate()` and `new LogTimestamp(new Date())` with `LogTimestamp.now()` to hide UUID and clock concerns behind domain factories.
- Introduce a `Logger` port in the application layer and a `ConsoleLogger` adapter in the infrastructure layer; inject it via the constructor instead of calling `console.*` directly.

## Motivation
`LogUseCaseImpl.createLog` previously carried responsibilities that did not belong to the core orchestration:

- **VO validation** — leaked from the boundary into the use case.
- **UUID generation** — direct dependency on the `uuid` library.
- **Current time acquisition** — direct dependency on `new Date()`.
- **`console.*` writes** — direct dependency on stdout, breaking the dependency-inversion rule of Clean Architecture.

After this change the use case depends only on domain types and the `Logger` interface; infrastructure concerns are pushed to the edges (controller for input boundary, factories for ID/clock, `Logger` port for output).

## Test plan
- [x] `npx jest` — 95/95 passing (7 new tests for `Id.generate`, `Timestamp.now`, and `ConsoleLogger`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)